### PR TITLE
add setup.py for proper pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import setuptools
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="pysmtb",
+    version="0.0.1",
+    author="Sebastian Merzbach",
+    author_email="merzbach@cs.uni-bonn.de",
+    description="python toolbox of (mostly) image-related helper / visualization functions",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        "matplotlib",
+        "visdom",
+        "torch",
+        "importlib",
+        "PyQt5",
+        "imageio",
+        "colour-science"
+    ],
+    python_requires=">=3.6",
+)


### PR DESCRIPTION
Installing pysmtb via pip requires to specify  "egg=<module_name>" behind the github URL. The module name has to match the one specified in the setup.py. Since no setup.py was present, one had to use something like "UNKOWN" to make it work somehow. Using the new setup.py file, one can just use the much more intuitive "pysmtb" with the additional benefit of requirements being installed automatically.